### PR TITLE
Add timezone offset to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ import ds3231
 rtc = ds3231.ds3231()
 rtc.set_time(time.time())
 ```
-This may be in GMT time. If it is, and you want to offset your timezone in seconds, you can do that (example here is EDT)
+This may be in UTC time. If it is, and you want to offset your timezone in seconds, you can do that (example here is EDT)
 ```
 rtc.set_time(time.time()-14400)
 ```

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ import ds3231
 rtc = ds3231.ds3231()
 rtc.set_time(time.time())
 ```
-This may be in GMT time. If it is, and you want to offset your timezone in seconds, you can do that (example here is EST)
+This may be in GMT time. If it is, and you want to offset your timezone in seconds, you can do that (example here is EDT)
 ```
 rtc.set_time(time.time()-14400)
 ```

--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ import ds3231
 rtc = ds3231.ds3231()
 rtc.set_time(time.time())
 ```
+This may be in GMT time. If it is, and you want to offset your timezone in seconds, you can do that (example here is EST)
+```
+rtc.set_time(time.time()-14400)
+```
 
 ### Case 
 A 3d printable case for this project can be found [here](https://www.thingiverse.com/thing:4916482).


### PR DESCRIPTION
Added a way to compensate for timezone, as I found it difficult to set time.time() to the proper timezone - its easier to bypass that when setting the ds3231 clock.