### PR TITLE
Adds fallback support for earlier versions of the Waveshare RTC module

### DIFF
--- a/ds3231.py
+++ b/ds3231.py
@@ -14,6 +14,7 @@ class ds3231(object):
             self.bus = I2C(i2c_port, scl=Pin(i2c_scl), sda=Pin(i2c_sda))
             self.bus.readfrom_mem(int(self.address), int(self.start_reg), 7)
         except OSError:
+            # Fall back to i2c port 1 (pins 6,7) used by earlier, but still common, versions of the Waveshare RTC module
             self.bus = I2C(1, scl=Pin(7), sda=Pin(6))
             self.bus.readfrom_mem(int(self.address), int(self.start_reg), 7)
 

--- a/ds3231.py
+++ b/ds3231.py
@@ -10,8 +10,12 @@ class ds3231(object):
     status_reg = 0x0f
 
     def __init__(self, i2c_port = 0, i2c_scl = 21, i2c_sda = 20):
-        self.bus = I2C(i2c_port, scl=Pin(i2c_scl), sda=Pin(i2c_sda))
-
+        try:
+            self.bus = I2C(i2c_port, scl=Pin(i2c_scl), sda=Pin(i2c_sda))
+            self.bus.readfrom_mem(int(self.address), int(self.start_reg), 7)
+        except OSError:
+            self.bus = I2C(1, scl=Pin(7), sda=Pin(6))
+            self.bus.readfrom_mem(int(self.address), int(self.start_reg), 7)
 
     def set_time(self, new_time):
         ti = time.localtime(new_time)


### PR DESCRIPTION
There seems to be a lot of new old stock of an earlier version of the Waveshare RTC module that uses i2c port 1 on pins 6/7 instead of port 0.  This small change falls back to port 1 if a read of the RTC fails on port 0.

A few others have tested my fork based on conversations in #6 and haven't reported any issues.  Feel free to implement this a different way if this isn't the best approach.